### PR TITLE
fix: apiManager 사용하지 않고 직접 axios 함수 호출 #58

### DIFF
--- a/src/Pages/HomePage/index.jsx
+++ b/src/Pages/HomePage/index.jsx
@@ -19,12 +19,17 @@ function Home() {
 
   const getSummary = async () => {
     try {
-      const userAttendanceStateApi = `/statistic/${_intraId}/userAttendanceState`
-      const response = await requestGet(userAttendanceStateApi);
-      
-      // await axios.get(
-      //   `https://${process.env.REACT_APP_AWS_BACKEND_SERVER}/statistic/${_intraId}/userAttendanceState`
-      // );
+      const userAttendanceStateApi = `/statistic/${_intraId}/userAttendanceState`;
+      // const response = await requestGet(userAttendanceStateApi);
+      const config = {
+        headers: {
+          authorization: `Bearer ${localStorage.get("accessToken")}`,
+        },
+      };
+      console.log(config);
+      const response = await axios.get(
+        `https://${process.env.REACT_APP_AWS_BACKEND_SERVER}/statistic/${_intraId}/userAttendanceState`
+      );
       console.log(response.data);
       setSummary(response.data);
     } catch (error) {
@@ -61,6 +66,6 @@ function Home() {
       <TestButtons />
     </>
   );
-};
+}
 
 export default Home;


### PR DESCRIPTION
- axios 커스텀 함수인 apiManager 를 사용하지 않고 axios 함수를 직접 호출하도록 수정했습니다.