### PR TITLE
docs: Set CI environment variable empty

### DIFF
--- a/.github/workflows/develop-deploy.yml
+++ b/.github/workflows/develop-deploy.yml
@@ -28,6 +28,8 @@ jobs:
 
       - name: Build
         run: yarn run build
+        env:
+          CI: ''
 
       - name: Deploy
         env:


### PR DESCRIPTION
```
Treating warnings as errors because process.env.CI = true.
```
오류를 해결하기 위해 CI 환경변수를 추가했습니다.