### PR TITLE
docs: Change ubuntu version latest to 18.04

### DIFF
--- a/.github/workflows/develop-deploy.yml
+++ b/.github/workflows/develop-deploy.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3
@@ -22,7 +22,7 @@ jobs:
           restore-keys: |
             ${{ runner.OS }}-build-
             ${{ runner.OS }}-
- 
+
       - name: Install Dependencies
         run: yarn install
 


### PR DESCRIPTION
```
<botocore.awsrequest.AWSRequest object at 0x7f224f3b9520>
Error: Process completed with exit code 255.
```
위의 오류를 해결하기 위해 runs-on 항목의 `ubuntu-latest` 를 `ubuntu-18.04` 로 변경했습니다.

[참고자료 : Velog](https://velog.io/@rud285/botocore.awsrequest.AWSRequest-object-at-0x7f37ea551278errorProcess-completed-with-exit-code-255)