### PR TITLE
docs: Add AWS Credentials configure

### DIFF
--- a/.github/workflows/develop-deploy.yml
+++ b/.github/workflows/develop-deploy.yml
@@ -24,10 +24,17 @@ jobs:
             ${{ runner.OS }}-
 
       - name: Install Dependencies
-        run: yarn install
+        run: npm install
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
 
       - name: Build
-        run: yarn run build
+        run: npm run build
         env:
           CI: ''
 


### PR DESCRIPTION
```
Unable to locate credentials. You can configure credentials by running "aws configure".
Error: Process completed with exit code 253.
```
`Invalidate cache CloudFront` 작업 중 위와 같은 오류를 해결하기 위해 
- `aws-actions/configure-aws-credentials@v1` 를 추가했습니다.
- [참고자료](https://anora.tistory.com/20)