### PR TITLE
fix: 오늘의 단어 설정 시 jwt 토큰 함께 전송 #90

### DIFF
--- a/src/pages/HomePage/SetTodayWordButton.jsx
+++ b/src/pages/HomePage/SetTodayWordButton.jsx
@@ -30,12 +30,17 @@ const SetTodayWordButton = () => {
     event.preventDefault();
     const inputValue = event.target.setTodayWord.value;
     try {
+      const config = {
+        headers: {
+          authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+        },
+      };
       const response = await axios.patch(
         `https://${process.env.REACT_APP_AWS_BACKEND_SERVER}/operator/setTodayWord`,
         {
           intraId: _intraId,
           todayWord: inputValue,
-        }
+        }, config
       );
       if (response.status === 200) {
         setOpen(false);


### PR DESCRIPTION
- fix: SetTodayWordButton 컴포넌트에서 오늘의 단어 설정 시 jwt 토큰을 함께 보내도록 `config` 변수를 추가했습니다.
- 오늘의 단어 설정 후 데이터 베이스에 정상적으로 반영되는지 확인 부탁드립니다.