### PR TITLE
Fix/modify set today word button#114

### DIFF
--- a/src/pages/HomePage/SetTodayWordButton.jsx
+++ b/src/pages/HomePage/SetTodayWordButton.jsx
@@ -14,9 +14,12 @@ const HTTP_STATUS = require("http-status");
 const SetTodayWordButton = () => {
   const [open, setOpen] = useState(false);
   const [isSnackbarOpen, setIsSnackbarOpen] = useState(false);
+  const [isErrorOccured, setIsErrorOccurred] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
   const [todayWord, setTodayWord] = useState("");
 
-  const handleClickOpen = (event) => {
+  const handleClickOpen = () => {
+    setIsErrorOccurred(false);
     setOpen(true);
   };
 
@@ -31,7 +34,7 @@ const SetTodayWordButton = () => {
   const handleSubmit = async (event) => {
     event.preventDefault();
     const inputValue = event.target.setTodayWord.value;
-    try {
+    try {      
       const data = {
         todayWord: inputValue,
       };
@@ -44,6 +47,8 @@ const SetTodayWordButton = () => {
       }
     } catch (error) {
       console.log(error);
+      setIsErrorOccurred(true);
+      setErrorMessage(error.message);
     }
   };
 
@@ -58,6 +63,11 @@ const SetTodayWordButton = () => {
         오늘의 단어 설정
       </Button>
       <Dialog open={open} onClose={handleClose}>
+        {isErrorOccured && (
+          <Alert severity="warning" sx={{ width: "100%" }}>
+            {errorMessage}
+          </Alert>
+        )}
         <DialogTitle>오늘의 단어를 설정해주세요.</DialogTitle>
         <Box component="form" onSubmit={handleSubmit}>
           <DialogContent>

--- a/src/pages/HomePage/SetTodayWordButton.jsx
+++ b/src/pages/HomePage/SetTodayWordButton.jsx
@@ -9,21 +9,23 @@ import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
 import Snackbar from "@mui/material/Snackbar";
 import Alert from "@mui/material/Alert";
-import useStore from "../../store.js";
+const HTTP_STATUS = require("http-status");
 
 const SetTodayWordButton = () => {
-  const { _intraId } = useStore((state) => state);
-
   const [open, setOpen] = useState(false);
-  const [isSetTodayWord, setIsTodayWord] = useState(false);
+  const [isSnackbarOpen, setIsSnackbarOpen] = useState(false);
   const [todayWord, setTodayWord] = useState("");
 
-  const handleClickOpen = () => {
+  const handleClickOpen = (event) => {
     setOpen(true);
   };
 
   const handleClose = () => {
     setOpen(false);
+  };
+
+  const handleSnackbar = () => {
+    setIsSnackbarOpen(false);
   };
 
   const handleSubmit = async (event) => {
@@ -35,9 +37,9 @@ const SetTodayWordButton = () => {
       };
       const response = await apiManager.patch(`/operator/setTodayWord/`, data);
 
-      if (response.status === 200) {
+      if (response.status === HTTP_STATUS.OK) {
         setOpen(false);
-        setIsTodayWord(true);
+        setIsSnackbarOpen(true);
         setTodayWord(inputValue);
       }
     } catch (error) {
@@ -75,11 +77,15 @@ const SetTodayWordButton = () => {
         </Box>
       </Dialog>
       <Snackbar
-        open={isSetTodayWord}
+        open={isSnackbarOpen}
         autoHideDuration={2000}
-        onClose={handleClose}
+        onClose={handleSnackbar}
       >
-        <Alert onClose={handleClose} severity="success" sx={{ width: "100%" }}>
+        <Alert
+          onClose={handleSnackbar}
+          severity="success"
+          sx={{ width: "100%" }}
+        >
           오늘의 단어가 "{todayWord}" 로 설정되었습니다.
         </Alert>
       </Snackbar>


### PR DESCRIPTION
- fix: 오늘의 단어 설정 후 다시 팝업창이 뜨지 않는 문제를 수정했습니다.
- fix: 오늘의 단어 설정 후 하단에 표시되는 팝업창이 닫히지 않는 문제를 수정했습니다.
- feat: 오늘의 단어 설정 창에서 에러가 발생하면 에러 메세지를 상단에 표시하도록 추가했습니다.
- feat: `http-status` 라이브러리를 사용해서 number 형 status code 대신 enum 으로 변경했습니다. 
  - `200` -> `HTTP_STATUS.OK`