### PR TITLE
Fix/update after attendance#116

### DIFF
--- a/src/pages/HomePage/AttendanceButton.jsx
+++ b/src/pages/HomePage/AttendanceButton.jsx
@@ -12,10 +12,11 @@ import useStore from "../../store.js";
 
 const AttendanceButton = () => {
   const [open, setOpen] = useState(false);
-  const [buttonStatus, setButton] = useState(true);
+  const [buttonStatus, setButtonStatus] = useState(0);
   const [buttonLetter, setButtonLetter] = useState("출석체크");
   const [isSameWithTodayWord, setIsSameWithTodayWord] = useState(true);
-  const { _intraId, _isAttended, setIsAttended } = useStore((state) => state);
+  const _attendanceCount = useStore((state) => state);
+  const increaseAttendanceCount = useStore((state) => state.increaseAttendanceCount);
 
   const handleClickOpen = () => {
     setOpen(true);
@@ -42,7 +43,7 @@ const AttendanceButton = () => {
       if (response.status === 201) {
         if (response.data.statusAttendance === 0) {
           setOpen(false);
-          setIsAttended(true);
+          increaseAttendanceCount(_attendanceCount);
         } else if (response.data.statusAttendance === 2) {
           setIsSameWithTodayWord(false);
         }
@@ -55,9 +56,10 @@ const AttendanceButton = () => {
   const checkButtonStatus = async () => {
     try {
       const response = await apiManager.get("/attendance/buttonStatus/");
-      setButton(response.data);
+      setButtonStatus(response.data);
 
-      if (response.data === 1) setButtonLetter("출석가능 시간이 아닙니다.");
+      if (response.data === 1)
+        setButtonLetter("출석가능 시간이 아닙니다.");
       else if (response.data === 2)
         setButtonLetter("이미 출석체크를 완료했습니다.");
       else if (response.data === 3)
@@ -69,7 +71,7 @@ const AttendanceButton = () => {
   // TODO 출석이 완료되면 출석 정보가 업데이트 되도록 수정하기
   useEffect(() => {
     checkButtonStatus();
-  }, [_isAttended]);
+  }, [_attendanceCount]);
 
   return (
     <>

--- a/src/pages/HomePage/AttendanceLog.jsx
+++ b/src/pages/HomePage/AttendanceLog.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import apiManager from "../../api/apiManager.js";
 import TableCell from "@mui/material/TableCell";
 import TableRow from "@mui/material/TableRow";
@@ -11,10 +11,9 @@ import { format } from "date-fns";
 import { ko } from "date-fns/locale";
 import useStore from "../../store.js";
 
-const AttendanceLog = ({ open, attendanceLog }) => {
-  const { _isAttended, _attendanceLog, setAttendanceLog } = useStore(
-    (state) => state
-  );
+const AttendanceLog = ({ open }) => {
+  const { _attendanceCount } = useStore((state) => state);
+  const [attendanceLog, setAttendanceLog] = useState([]);
   useEffect(() => {
     const getAttendanceLog = async () => {
       try {
@@ -33,9 +32,9 @@ const AttendanceLog = ({ open, attendanceLog }) => {
       }
     };
     getAttendanceLog();
-  }, [_isAttended]);
+  }, [_attendanceCount]);
 
-  if (_attendanceLog !== undefined && _attendanceLog.length === 0) {
+  if (attendanceLog !== undefined && attendanceLog.length === 0) {
     return;
   } else {
     return (
@@ -51,7 +50,7 @@ const AttendanceLog = ({ open, attendanceLog }) => {
                   </TableRow>
                 </TableHead>
                 <TableBody>
-                  {_attendanceLog.map((log) => (
+                  {attendanceLog.map((log) => (
                     <TableRow key={log.date}>
                       <TableCell component="th" scope="row">
                         {log.date}

--- a/src/pages/HomePage/AttendanceSummary.jsx
+++ b/src/pages/HomePage/AttendanceSummary.jsx
@@ -9,15 +9,15 @@ import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
 import useStore from "../../store.js";
 
 function AttendanceSummary() {
-  const { _summary, setSummary, _isAttended } = useStore(
-    (state) => state
-  );
+  const { _summary, setSummary, _attendanceCount, setAttendanceCount } =
+    useStore((state) => state);
   const [open, setOpen] = useState(false);
 
   const getSummary = async () => {
     try {
       const response = await apiManager.get("/statistic/userAttendanceState/");
       setSummary(response.data);
+      setAttendanceCount(response.data.attendanceCount);
     } catch (error) {
       console.log(error);
     }
@@ -25,7 +25,7 @@ function AttendanceSummary() {
 
   useEffect(() => {
     getSummary();
-  }, [_isAttended]);
+  }, [_attendanceCount]);
 
   return (
     <React.Fragment>

--- a/src/pages/HomePage/AttendanceTable.jsx
+++ b/src/pages/HomePage/AttendanceTable.jsx
@@ -19,7 +19,9 @@ const AttendanceTable = (props) => {
           </TableRow>
         </TableHead>
 
-        <TableBody>{props.children}</TableBody>
+        <TableBody>
+          {props.children}
+        </TableBody>
       </Table>
     </TableContainer>
   );

--- a/src/pages/HomePage/index.jsx
+++ b/src/pages/HomePage/index.jsx
@@ -8,7 +8,6 @@ import TodayDate from "./TodayDate";
 import AttendanceSummary from "./AttendanceSummary";
 import Link from "@mui/material/Link";
 import useStore from "../../store.js";
-import TestButtons from "./TestButtons";
 
 function Home() {
   const { _intraId, _photoUrl, setPhotoUrl } = useStore((state) => state);
@@ -35,7 +34,6 @@ function Home() {
     <>
       <UserProfile intraId={_intraId} photoUrl={_photoUrl} />
       <TodayDate />
-      {/* <AttendanceSummary /> */}
       <AttendanceTable>
         <AttendanceSummary />
       </AttendanceTable>
@@ -48,7 +46,6 @@ function Home() {
         구글 출석폼에서도 입력 부탁드려용 ! →
       </Link>
       {isOperator && <SetTodayWordButton />}
-      {/* <TestButtons /> */}
     </>
   );
 }

--- a/src/store.js
+++ b/src/store.js
@@ -6,11 +6,9 @@ const useStore = create(
     (set) => ({
       _intraId: "",
       setIntraId: (intraId) => set({ _intraId: intraId }),
-      _isAttended: false,
-      setIsAttended: () => set({ _isAttended: true }),
-      _attendanceLog: [],
-      setAttendanceLog: (attendanceLog) =>
-        set({ _attendanceLog: attendanceLog }),
+      _attendanceCount: 0,
+      setAttendanceCount: (attendanceCount) => set({ _attendanceCount: attendanceCount }),
+      increaseAttendanceCount: (prev) => set({ _attendanceCount: prev + 1 }),
       _photoUrl: "",
       setPhotoUrl: (photoUrl) => set({ _photoUrl: photoUrl }),
       _summary: {},


### PR DESCRIPTION
# 작업 개요
첫 로그인 시 출석체크를 하면 데이터 업데이트가 이루어지지만, 
브라우저의 로컬 스토리지를 날리지 않거나 시크릿 브라우저로 들어가지 않으면 데이터 업데이트가 이루어지지 않는 문제를 해결했습니다.
# 작업 내역
- feat: zustand 상태 관리에서 사용하던 `_isAttended` 와 `_attedanceLog` 를 삭제했습니다.
- feat: zustand 상태 관리에 `_attendanceCount` 를 추가했습니다. 이를 사용해서 데이터 업데이트가 이루어지도록 변경했습니다.