### PR TITLE
Feat/admin page layout#118

### DIFF
--- a/src/components/DesktopLayout.jsx
+++ b/src/components/DesktopLayout.jsx
@@ -101,7 +101,7 @@ function DesktopLayout(props) {
         }}
       >
         <Toolbar />
-        <Container maxWidth="lg" sx={{ mt: 4, mb: 4 }}>
+        <Container maxWidth="xl" sx={{ mt: 4, mb: 4 }}>
           {/* Children components */}
           <Outlet />
           {/* Children components */}

--- a/src/pages/DashboardPage/SearchBar.jsx
+++ b/src/pages/DashboardPage/SearchBar.jsx
@@ -1,0 +1,31 @@
+import Box from "@mui/material/Box";
+import IconButton from "@mui/material/IconButton";
+import TextField from "@mui/material/TextField";
+import SearchIcon from "@mui/icons-material/Search";
+
+function SearchBar(props) {
+  const { setSearchQuery } = props;
+
+  const handleSearchQuery = (event) => {
+    event.preventDefault();
+    console.log(event.target.searchBar.value);
+    setSearchQuery(event.target.searchBar.value);
+  };
+
+  return (
+    <Box sx={{ mt: 2, mb: 2 }}component="form" onSubmit={handleSearchQuery}>
+      <TextField
+        id="searchBar"
+        label="Intra ID"
+        variant="outlined"
+        placeholder="Intra ID 를 입력하세요."
+        size="small"
+      />
+      <IconButton type="submit" aria-label="search">
+        <SearchIcon />
+      </IconButton>
+    </Box>
+  );
+}
+
+export default SearchBar;

--- a/src/pages/DashboardPage/UserAttedanceDataTable.jsx
+++ b/src/pages/DashboardPage/UserAttedanceDataTable.jsx
@@ -1,0 +1,60 @@
+import { useState } from "react";
+import SearchBar from "./SearchBar";
+import Grid from "@mui/material/Grid";
+import Box from "@mui/material/Box";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+import Typography from "@mui/material/Typography";
+import { DataGrid } from "@mui/x-data-grid";
+
+const columns = [{ field: "date", headerName: "날짜", width: 200 }];
+
+const rows = [
+  { id: 1, date: "2022-11-01" },
+  { id: 2, date: "2022-11-02" },
+  { id: 3, date: "2022-11-03" },
+  { id: 4, date: "2022-11-04" },
+  { id: 5, date: "2022-11-05" },
+  { id: 6, date: "2022-11-06" },
+  { id: 7, date: "2022-11-07" },
+  { id: 8, date: "2022-11-08" },
+];
+
+function UserAttendanceDataTable() {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectionModel, setSelectionModel] = useState(() =>
+    rows.filter((row) => row.id > 5).map((row) => row.id)
+  );
+  const [selectedRows, setSelectedRows] = useState([]);
+  return (
+    <Grid item xs={12}>
+      <Card>
+        <CardContent>
+          <Typography variant="h5" component="div">
+            DB 수정
+          </Typography>
+          <SearchBar
+            searchQuery={searchQuery}
+            setSearchQuery={setSearchQuery}
+          />
+          <Box sx={{ mt: 1, height: 400, width: "100%" }}>
+            <DataGrid
+              rows={rows}
+              columns={columns}
+              checkboxSelection
+              selectionModel={selectionModel}
+              onSelectionModelChange={(e) => {
+                setSelectionModel(e);
+                const selectedIDs = new Set(e);
+                const selectedRows = rows.filter((r) => selectedIDs.has(r.id));
+                setSelectedRows(selectedRows);
+              }}
+            />
+          </Box>
+        </CardContent>
+      </Card>
+    </Grid>
+  );
+}
+
+export default UserAttendanceDataTable;

--- a/src/pages/DashboardPage/index.jsx
+++ b/src/pages/DashboardPage/index.jsx
@@ -1,15 +1,10 @@
-import { useState } from "react";
 import DateSelector from "./DateSelector";
 import MonthlyUserInfo from "./MonthlyUserInfo";
 import MonthlyUserTable from "./MonthlyUserTable";
 import MonthlyPerfectUserTable from "./MonthlyPerfectUserTable";
+import UserAttendanceDataTable from "./UserAttedanceDataTable";
 import Grid from "@mui/material/Grid";
-import Paper from "@mui/material/Paper";
 import Container from "@mui/material/Container";
-import Card from "@mui/material/Card";
-import Typography from "@mui/material/Typography";
-import CardContent from "@mui/material/CardContent";
-import Box from "@mui/material/Box";
 
 function DashboardPage() {
   return (
@@ -29,13 +24,7 @@ function DashboardPage() {
         <MonthlyPerfectUserTable />
 
         {/* EXPLAIN: 출석 데이터 수정 */}
-        <Grid item xs={12}>
-          <Paper sx={{ p: 2, display: "flex", flexDirection: "column" }}>
-            <Typography variant="h5" component="div">
-              DB 수정
-            </Typography>
-          </Paper>
-        </Grid>
+        <UserAttendanceDataTable />
       </Grid>
     </Container>
   );


### PR DESCRIPTION
# 작업 내용
- 대시보드 레이아웃 너비 조정 (전체 화면이 커져도 꽉 찰 수 있게끔)
- 인트라 검색창 컴포넌트 추가
- 출석한 날짜를 보여주는 테이블 추가

# TODO
## 검색창
- 인트라 검색창 입력 후 유저 출석 정보 가져오는지 확인

## 출석 데이터 테이블
- 체크박스 선택 및 해제 시 API 요청할 수 있는 방법 찾기

# 참고자료
- [Create a Search Bar with React and Material UI (dev.to)](https://dev.to/mar1anna/create-a-search-bar-with-react-and-material-ui-4he)
- [can-i-initialize-the-checkbox-selection-in-a-material-ui-datagrid (codesandbox)](https://codesandbox.io/s/64104554-can-i-initialize-the-checkbox-selection-in-a-material-ui-datagrid-6pjrg?file=/demo.tsx:1740-1972)
- [MUI DataGrid default select row 설정하기 (velog)](https://velog.io/@dlruddms5619/MUI-Datagrid-selected-row-%EA%B0%92-%EA%B0%80%EC%A0%B8%EC%98%A4%EA%B8%B0)